### PR TITLE
Update fb login feature{Issue:FB OAuth2(callback:=>invalid_credentials)}

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,4 +1,5 @@
 class QuizzesController < ApplicationController
+  #skip_before_filter :authenticate_user
   before_action :set_quiz, only: [:show, :edit, :update, :destroy]
   before_filter :authenticate_user!, only: [:new, :edit, :update, :destroy]
 
@@ -36,7 +37,9 @@ class QuizzesController < ApplicationController
         format.json { render json: @quiz.errors, status: :unprocessable_entity }
       end
     end
+
   end
+
 
   # PATCH/PUT /quizzes/1
   # PATCH/PUT /quizzes/1.json

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,7 @@ class User < ActiveRecord::Base
                          password: Devise.friendly_token[0,20]
                         )
     end
-    user
+    return user
   end
   has_many :quizzes
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,10 @@
+OmniAuth.config.on_failure do |env|
+	[200, {}, [env['omniauth.error'].inspect]]
+end
 Rails.application.config.middleware.use OmniAuth::Builder do
 	  provider :facebook, ENV['FACEBOOK_APP_KEY'], ENV['FACEBOOK_APP_SECRET'],
-		   :scope => 'email,read_stream',
-		   :display => 'popup'
+		   :scope => 'email',
+		   #:scope => 'fb_permissions', 
+		   :provider_ignores_state => true, 
+		   :display => 'page'
 end

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,6 @@
 OmniAuth.config.on_failure do |env|
 	[200, {}, [env['omniauth.error'].inspect]]
+	[200, {}, [env['omniauth.auth'].inspect]]
 end
 Rails.application.config.middleware.use OmniAuth::Builder do
 	  provider :facebook, ENV['FACEBOOK_APP_KEY'], ENV['FACEBOOK_APP_SECRET'],


### PR DESCRIPTION
Add the omniauth failure inspector. The error of "invalid_credentials" is actually depending on OAuth callback operation between the "Cross-Site Request Forgery" validation feature on FB OAuth's provider and OAuth's operation of [omniauth-facebook](https://github.com/cmer/omniauth-facebook/tree/rollback-omniauth-oauth2) library. 
Can you repair it? 

When we see the Auth Hash, we got that the token are expired and it has not been renew token again from the FB?
[Here](https://gist.github.com/stevebourne/2394427) may be the answer?? 
Can you repair it? 
